### PR TITLE
Error logging params fix

### DIFF
--- a/lib/sbmt/outbox/error_tracker.rb
+++ b/lib/sbmt/outbox/error_tracker.rb
@@ -6,7 +6,7 @@ module Sbmt
       class << self
         def error(message, params = {})
           unless defined?(Sentry)
-            Outbox.logger.log_error(message, params)
+            Outbox.logger.log_error(message, **params)
             return
           end
 


### PR DESCRIPTION
Fixed Logger#log_error call to conform to Ruby v3 syntax

# Context

- sbmt-outbox process errors with "wrong number of arguments" error while trying to perform its internal error logging 

## Related tickets

- none found

# What's inside

- [x] fixed `Logger#log_error` call in Sbmt::Outbox::ErrorTracker::error